### PR TITLE
Miscellaneous Patches

### DIFF
--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/ArbitriumRobes/ArbitriumRobesArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/ArbitriumRobes/ArbitriumRobesArmorItem.java
@@ -29,7 +29,7 @@ public class ArbitriumRobesArmorItem extends ImbuableHnSArmorItem implements IDi
     public ArbitriumRobesArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 300.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         this.dispatcher = new HnSArmorDispatcher();
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/ArbitriumRobes/ArbitriumRobesElytraArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/ArbitriumRobes/ArbitriumRobesElytraArmorItem.java
@@ -30,7 +30,7 @@ public class ArbitriumRobesElytraArmorItem extends ImbuableHnSArmorItem implemen
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(ALObjects.Attributes.ELYTRA_FLIGHT, 1, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 300.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         this.dispatcher = new HnSArmorDispatcher();
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/Blazeborne/BlazeborneArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/Blazeborne/BlazeborneArmorItem.java
@@ -29,9 +29,9 @@ public class BlazeborneArmorItem extends ImbuableHnSArmorItem implements IDisabl
     public BlazeborneArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.SERAPH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/CreakingSorcerer/CreakingSorcererArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/CreakingSorcerer/CreakingSorcererArmorItem.java
@@ -29,7 +29,7 @@ public class CreakingSorcererArmorItem extends ImbuableHnSArmorItem implements I
     public CreakingSorcererArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 500.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/DarkRitualTemplar/DarkRitualTemplarArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/DarkRitualTemplar/DarkRitualTemplarArmorItem.java
@@ -32,8 +32,8 @@ public class DarkRitualTemplarArmorItem extends ImbuableHnSArmorItem implements 
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(Attributes.ATTACK_DAMAGE, 0.5, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(Attributes.ATTACK_SPEED, 0.15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/EnderDragon/EnderDragonArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/EnderDragon/EnderDragonArmorItem.java
@@ -29,9 +29,9 @@ public class EnderDragonArmorItem extends ImbuableHnSArmorItem implements IDisab
     public EnderDragonArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.ENDER_DRAGON_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/FireblossomBattlemage/FireblossomBattlemageCrownedArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/FireblossomBattlemage/FireblossomBattlemageCrownedArmorItem.java
@@ -30,9 +30,9 @@ public class FireblossomBattlemageCrownedArmorItem extends ImbuableHnSArmorItem 
     public FireblossomBattlemageCrownedArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.FIREBLOSSOM_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/FireblossomBattlemage/FireblossomBattlemageHelmetArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/FireblossomBattlemage/FireblossomBattlemageHelmetArmorItem.java
@@ -30,9 +30,9 @@ public class FireblossomBattlemageHelmetArmorItem extends ImbuableHnSArmorItem i
     public FireblossomBattlemageHelmetArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.FIREBLOSSOM_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/GabrielULTRAKILL/GabrielArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/GabrielULTRAKILL/GabrielArmorItem.java
@@ -31,8 +31,8 @@ public class GabrielArmorItem extends ImbuableHnSArmorItem implements IDisableJa
     public GabrielArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         this.dispatcher = new HnSArmorDispatcher();
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/GabrielULTRAKILL/GabrielElytraArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/GabrielULTRAKILL/GabrielElytraArmorItem.java
@@ -35,8 +35,8 @@ public class GabrielElytraArmorItem extends ImbuableHnSArmorItem implements IDis
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(ALObjects.Attributes.ELYTRA_FLIGHT, 1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         this.dispatcher = new HnSArmorDispatcher();
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/Infestation/InfestationArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/Infestation/InfestationArmorItem.java
@@ -29,8 +29,8 @@ public class InfestationArmorItem extends ImbuableHnSArmorItem implements IDisab
     public InfestationArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.INFESTATION_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         this.dispatcher = new HnSArmorDispatcher();
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/LemonGod/Ascended/AscendedLemonGodArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/LemonGod/Ascended/AscendedLemonGodArmorItem.java
@@ -29,7 +29,7 @@ public class AscendedLemonGodArmorItem extends ImbuableHnSArmorItem implements I
     public AscendedLemonGodArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 500.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/LemonGod/LemonGodArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/LemonGod/LemonGodArmorItem.java
@@ -28,8 +28,8 @@ public class LemonGodArmorItem extends ImbuableHnSArmorItem implements IDisableJ
     public LemonGodArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/SLCCat/SLCCatArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/SLCCat/SLCCatArmorItem.java
@@ -29,8 +29,8 @@ public class SLCCatArmorItem extends ImbuableHnSArmorItem implements IDisableJac
     public SLCCatArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.SLC_CAT_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/Seraph/SeraphArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/Seraph/SeraphArmorItem.java
@@ -27,9 +27,9 @@ public class SeraphArmorItem extends ImbuableHnSArmorItem implements IDisableJac
     public SeraphArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.SERAPH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
 
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/SoulFlame/SoulFlameArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/SoulFlame/SoulFlameArmorItem.java
@@ -30,9 +30,9 @@ public class SoulFlameArmorItem extends ImbuableHnSArmorItem implements IDisable
     public SoulFlameArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.SOUL_FLAME_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/SupremeWitch/SupremeWitchArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/SupremeWitch/SupremeWitchArmorItem.java
@@ -29,9 +29,9 @@ public class SupremeWitchArmorItem extends ImbuableHnSArmorItem implements IDisa
     public SupremeWitchArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.SUPREME_WITCH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/TheWither/TheWitherArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/AzureLib/TheWither/TheWitherArmorItem.java
@@ -28,9 +28,9 @@ public class TheWitherArmorItem extends ImbuableHnSArmorItem implements IDisable
     public TheWitherArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.SERAPH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         // Create the instance of the class here to use later.
         this.dispatcher = new HnSArmorDispatcher();

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/AbberantPredator/AbberantPredatorArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/AbberantPredator/AbberantPredatorArmorItem.java
@@ -30,9 +30,9 @@ public class AbberantPredatorArmorItem extends ImbuableGeckolibHnSArmorItem impl
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.DARK_RITUAL_TEMPLAR_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(HnSAttributeRegistry.SHADOW_MAGIC_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(HnSAttributeRegistry.SHADOW_MAGIC_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/AlchemistSupreme/AlchemistSupremeArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/AlchemistSupreme/AlchemistSupremeArmorItem.java
@@ -28,9 +28,9 @@ public class AlchemistSupremeArmorItem extends ImbuableGeckolibHnSArmorItem impl
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.SUPREME_WITCH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ArbitriumRobes/GeckolibArbitriumRobesArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ArbitriumRobes/GeckolibArbitriumRobesArmorItem.java
@@ -35,7 +35,7 @@ public class GeckolibArbitriumRobesArmorItem extends ImbuableGeckolibHnSArmorIte
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 500.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
               );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ArbitriumRobes/GeckolibArbitriumRobesElytraItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ArbitriumRobes/GeckolibArbitriumRobesElytraItem.java
@@ -33,7 +33,7 @@ public class GeckolibArbitriumRobesElytraItem extends ImbuableChestplateArmorIte
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 500.0, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(ALObjects.Attributes.ELYTRA_FLIGHT, 1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Blazeborne/GeckolibBlazeborneArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Blazeborne/GeckolibBlazeborneArmorItem.java
@@ -29,9 +29,9 @@ public class GeckolibBlazeborneArmorItem extends ImbuableGeckolibHnSArmorItem im
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.BLAZEBORNE_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/BountyHunter/BountyHunterArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/BountyHunter/BountyHunterArmorItem.java
@@ -23,8 +23,8 @@ public class BountyHunterArmorItem extends ImbuableGeckolibHnSArmorItem implemen
     public BountyHunterArmorItem(Type type, Properties settings) {
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.ARCHER_MATERIAL, type, settings,
-                new AttributeContainer(ALObjects.Attributes.ARROW_DAMAGE, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(ALObjects.Attributes.ARROW_VELOCITY, .1, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(ALObjects.Attributes.ARROW_DAMAGE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(ALObjects.Attributes.ARROW_VELOCITY, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(Attributes.MOVEMENT_SPEED, .25, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
         );
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Calamitas/CalamitasArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Calamitas/CalamitasArmorItem.java
@@ -29,9 +29,9 @@ public class CalamitasArmorItem extends ImbuableGeckolibHnSArmorItem implements 
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CALAMITAS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Calamitas/CalamitasChestplateArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Calamitas/CalamitasChestplateArmorItem.java
@@ -45,9 +45,9 @@ public class CalamitasChestplateArmorItem extends ImbuableGeckolibHnSArmorItem i
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CALAMITAS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ChargedScourge/GeckolibChargedScourgeArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ChargedScourge/GeckolibChargedScourgeArmorItem.java
@@ -29,9 +29,9 @@ public class GeckolibChargedScourgeArmorItem extends ImbuableGeckolibHnSArmorIte
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CHARGED_SCOURGE_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.LIGHTNING_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.LIGHTNING_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/ChlorophyteArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/ChlorophyteArmorItem.java
@@ -28,8 +28,8 @@ public class ChlorophyteArmorItem extends ImbuableGeckolibHnSArmorItem implement
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/Headgear/ChlorophyteHeadgearArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/Headgear/ChlorophyteHeadgearArmorItem.java
@@ -29,8 +29,8 @@ public class ChlorophyteHeadgearArmorItem extends ImbuableGeckolibHnSArmorItem i
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/Helmet/ChlorophyteHelmetArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/Helmet/ChlorophyteHelmetArmorItem.java
@@ -32,7 +32,7 @@ public class ChlorophyteHelmetArmorItem extends ImbuableGeckolibHnSArmorItem imp
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(ALObjects.Attributes.ARROW_DAMAGE, 1.0, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(ALObjects.Attributes.ARROW_VELOCITY, 1.0, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/Mask/ChlorophyteMaskArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Chlorophyte/Mask/ChlorophyteMaskArmorItem.java
@@ -31,7 +31,7 @@ public class ChlorophyteMaskArmorItem extends ImbuableGeckolibHnSArmorItem imple
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(Attributes.ATTACK_DAMAGE, 3.0, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(Attributes.ATTACK_SPEED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/CreakingSorcerer/GeckolibCreakingSorcererArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/CreakingSorcerer/GeckolibCreakingSorcererArmorItem.java
@@ -29,9 +29,9 @@ public class GeckolibCreakingSorcererArmorItem extends ImbuableGeckolibHnSArmorI
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/CryogenicRuler/CryogenicRulerArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/CryogenicRuler/CryogenicRulerArmorItem.java
@@ -29,9 +29,9 @@ public class CryogenicRulerArmorItem extends ImbuableGeckolibHnSArmorItem implem
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CRYOGENIC_RULER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/CrystalArachnid/CrystalArachnidArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/CrystalArachnid/CrystalArachnidArmorItem.java
@@ -29,9 +29,9 @@ public class CrystalArachnidArmorItem extends ImbuableGeckolibHnSArmorItem imple
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CRYOGENIC_RULER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/EnderDragon/GeckolibEnderDragonArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/EnderDragon/GeckolibEnderDragonArmorItem.java
@@ -29,9 +29,9 @@ public class GeckolibEnderDragonArmorItem extends ImbuableGeckolibHnSArmorItem i
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.ENDER_DRAGON_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/FleshMass/FleshMassArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/FleshMass/FleshMassArmorItem.java
@@ -29,9 +29,9 @@ public class FleshMassArmorItem extends ImbuableGeckolibHnSArmorItem implements 
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.FLESH_MASS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/FrostbiteHunter/FrostbiteHunterArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/FrostbiteHunter/FrostbiteHunterArmorItem.java
@@ -30,10 +30,10 @@ public class FrostbiteHunterArmorItem extends ImbuableGeckolibHnSArmorItem imple
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.HUNTER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 100.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(ALObjects.Attributes.ARROW_DAMAGE, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(ALObjects.Attributes.ARROW_VELOCITY, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(ALObjects.Attributes.ARROW_DAMAGE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(ALObjects.Attributes.ARROW_VELOCITY, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(Attributes.MOVEMENT_SPEED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
         );
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/FrostbiteKnight/FrostbiteKnightArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/FrostbiteKnight/FrostbiteKnightArmorItem.java
@@ -34,11 +34,11 @@ public class FrostbiteKnightArmorItem extends ImbuableGeckolibHnSArmorItem imple
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CRYOGENIC_RULER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 125.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(Attributes.ATTACK_SPEED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
                 new AttributeContainer(Attributes.ATTACK_DAMAGE, 1, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(ALObjects.Attributes.COLD_DAMAGE, 2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .1, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Hazel/HazelArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Hazel/HazelArmorItem.java
@@ -30,8 +30,8 @@ public class HazelArmorItem extends ImbuableGeckolibHnSArmorItem implements IDis
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.BLAZEBORNE_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Hazel/HazelHOLYMOLYArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Hazel/HazelHOLYMOLYArmorItem.java
@@ -30,8 +30,8 @@ public class HazelHOLYMOLYArmorItem extends ImbuableGeckolibHnSArmorItem impleme
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.BLAZEBORNE_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/HertaPuppet/HertaPuppetArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/HertaPuppet/HertaPuppetArmorItem.java
@@ -16,8 +16,8 @@ public class HertaPuppetArmorItem extends ImbuableGeckolibHnSArmorItem implement
     public HertaPuppetArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.CRYOGENIC_RULER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .125, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ICE_SPELL_POWER, .125, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Infestation/GeckolibInfestationArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Infestation/GeckolibInfestationArmorItem.java
@@ -29,8 +29,8 @@ public class GeckolibInfestationArmorItem extends ImbuableGeckolibHnSArmorItem i
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.DARK_RITUAL_TEMPLAR_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Iron431/Iron431ArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Iron431/Iron431ArmorItem.java
@@ -33,7 +33,7 @@ public class Iron431ArmorItem extends ImbuableGeckolibHnSArmorItem implements ID
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 500.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
               );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Legionnaire/OldLegionnaireArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Legionnaire/OldLegionnaireArmorItem.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class OldLegionnaireArmorItem extends ImbuableGeckolibHnSArmorItem implements IDisableJacket, IDisableHat {
     public OldLegionnaireArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.LEGIONNAIRE_MATERIAL, type, settings,
-                new AttributeContainer(AttributeRegistry.SPELL_RESIST, .05, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(AttributeRegistry.SPELL_RESIST, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(Attributes.MAX_HEALTH, 1.25, AttributeModifier.Operation.ADD_VALUE)
         );
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LegionnaireRuler/LegionnaireRulerArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LegionnaireRuler/LegionnaireRulerArmorItem.java
@@ -26,9 +26,9 @@ import java.util.List;
 public class LegionnaireRulerArmorItem extends ImbuableGeckolibHnSArmorItem {
     public LegionnaireRulerArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.LEGIONNAIRE_MATERIAL, type, settings,
-                new AttributeContainer(AttributeRegistry.SUMMON_DAMAGE, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .1, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(AttributeRegistry.SUMMON_DAMAGE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(Attributes.MAX_HEALTH, 1.25, AttributeModifier.Operation.ADD_VALUE)
         );
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LegionnaireRuler/Soul/SoulLegionnaireRulerArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LegionnaireRuler/Soul/SoulLegionnaireRulerArmorItem.java
@@ -26,9 +26,9 @@ import java.util.List;
 public class SoulLegionnaireRulerArmorItem extends ImbuableGeckolibHnSArmorItem {
     public SoulLegionnaireRulerArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.LEGIONNAIRE_MATERIAL, type, settings,
-                new AttributeContainer(AttributeRegistry.SUMMON_DAMAGE, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .1, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .1, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(AttributeRegistry.SUMMON_DAMAGE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(Attributes.MAX_HEALTH, 1.25, AttributeModifier.Operation.ADD_VALUE)
         );
     }

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LemonGod/Ascended/GeckolibAscendedLemonGodArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LemonGod/Ascended/GeckolibAscendedLemonGodArmorItem.java
@@ -28,8 +28,8 @@ public class GeckolibAscendedLemonGodArmorItem extends ImbuableGeckolibHnSArmorI
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LemonGod/GeckolibLemonGodArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/LemonGod/GeckolibLemonGodArmorItem.java
@@ -28,8 +28,8 @@ public class GeckolibLemonGodArmorItem extends ImbuableGeckolibHnSArmorItem impl
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CREAKING_SORCERER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MageHunter/MageHunterArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MageHunter/MageHunterArmorItem.java
@@ -16,9 +16,9 @@ import software.bernie.geckolib.renderer.GeoArmorRenderer;
 public class MageHunterArmorItem extends ImbuableGeckolibHnSArmorItem implements IDisableJacket, IDisableHat {
     public MageHunterArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.MAGEHUNTER_MATERIAL, type, settings,
-                new AttributeContainer(AttributeRegistry.SPELL_RESIST, .125, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, -.2, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.COOLDOWN_REDUCTION, -.1, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_RESIST, .125, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, -.2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.COOLDOWN_REDUCTION, -.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Maverick/MaverickArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Maverick/MaverickArmorItem.java
@@ -30,9 +30,9 @@ public class MaverickArmorItem extends ImbuableGeckolibHnSArmorItem implements I
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.MAVERICK_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MothicWitch/MothicWitchArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MothicWitch/MothicWitchArmorItem.java
@@ -28,8 +28,8 @@ public class MothicWitchArmorItem extends ImbuableGeckolibHnSArmorItem implement
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MothicWitch/NerfedMothicWitchArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MothicWitch/NerfedMothicWitchArmorItem.java
@@ -27,9 +27,9 @@ public class NerfedMothicWitchArmorItem extends ImbuableGeckolibHnSArmorItem imp
     public NerfedMothicWitchArmorItem(Type type, Properties settings) {
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
-                new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MyceliumGuardian/MyceliumGuardianArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MyceliumGuardian/MyceliumGuardianArmorItem.java
@@ -30,9 +30,9 @@ public class MyceliumGuardianArmorItem extends ImbuableGeckolibHnSArmorItem impl
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.DARK_RITUAL_TEMPLAR_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(HnSAttributeRegistry.RADIANCE_MAGIC_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(HnSAttributeRegistry.RADIANCE_MAGIC_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Neru/NeruArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Neru/NeruArmorItem.java
@@ -21,7 +21,7 @@ public class NeruArmorItem extends ImbuableChestplateArmorItem implements IDisab
     public NeruArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ProjectSekai/ProjectSekaiArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ProjectSekai/ProjectSekaiArmorItem.java
@@ -21,7 +21,7 @@ public class ProjectSekaiArmorItem extends ImbuableGeckolibHnSArmorItem implemen
     public ProjectSekaiArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/RottenGirl/RottenGirlArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/RottenGirl/RottenGirlArmorItem.java
@@ -21,7 +21,7 @@ public class RottenGirlArmorItem extends ImbuableGeckolibHnSArmorItem implements
     public RottenGirlArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SacredRobes/SacredRobesArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SacredRobes/SacredRobesArmorItem.java
@@ -33,7 +33,7 @@ public class SacredRobesArmorItem extends ImbuableGeckolibHnSArmorItem implement
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.NERFED_DEUS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 500.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
               );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Seraph/GeckolibSeraphArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Seraph/GeckolibSeraphArmorItem.java
@@ -27,9 +27,9 @@ public class GeckolibSeraphArmorItem extends ImbuableGeckolibHnSArmorItem {
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.SERAPH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ShadowScale/ShadowScaleArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ShadowScale/ShadowScaleArmorItem.java
@@ -32,9 +32,9 @@ public class ShadowScaleArmorItem extends ImbuableGeckolibHnSArmorItem implement
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.BATTLEMAGE_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(HnSAttributeRegistry.SHADOW_MAGIC_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
+                new AttributeContainer(HnSAttributeRegistry.SHADOW_MAGIC_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(ALObjects.Attributes.CRIT_CHANCE, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SoulFlame/GeckolibSoulFlameArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SoulFlame/GeckolibSoulFlameArmorItem.java
@@ -31,9 +31,9 @@ public class GeckolibSoulFlameArmorItem extends ImbuableGeckolibHnSArmorItem imp
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.SOUL_FLAME_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SupremeWitch/GeckolibSupremeWitchArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SupremeWitch/GeckolibSupremeWitchArmorItem.java
@@ -28,9 +28,9 @@ public class GeckolibSupremeWitchArmorItem extends ImbuableGeckolibHnSArmorItem 
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.SUPREME_WITCH_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SynthesizerV/SynthesizerVArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/SynthesizerV/SynthesizerVArmorItem.java
@@ -21,7 +21,7 @@ public class SynthesizerVArmorItem extends ImbuableChestplateArmorItem implement
     public SynthesizerVArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/TheWither/GeckolibTheWitherArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/TheWither/GeckolibTheWitherArmorItem.java
@@ -29,9 +29,9 @@ public class GeckolibTheWitherArmorItem extends ImbuableGeckolibHnSArmorItem imp
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.FLESH_MASS_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ThunderProwler/ThunderProwlerArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/ThunderProwler/ThunderProwlerArmorItem.java
@@ -29,9 +29,9 @@ public class ThunderProwlerArmorItem extends ImbuableGeckolibHnSArmorItem implem
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.CHARGED_SCOURGE_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.LIGHTNING_SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.LIGHTNING_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Utau/UtauArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/Utau/UtauArmorItem.java
@@ -21,7 +21,7 @@ public class UtauArmorItem extends ImbuableChestplateArmorItem implements IDisab
     public UtauArmorItem(Type type, Properties settings) {
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
                 new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
-                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_VALUE)
+                new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
     }
 

--- a/src/main/resources/assets/hazennstuff/lang/en_us.json
+++ b/src/main/resources/assets/hazennstuff/lang/en_us.json
@@ -792,10 +792,10 @@
   "school.hazennstuff.shadow": "Shadow",
 
   "attribute.hazennstuff.radiance_spell_power": "Radiance Spell Power",
-  "attribute.hazennstuff.radiance_spell_resist": "Radiance Spell Power",
+  "attribute.hazennstuff.radiance_magic_resist": "Radiance Magic Resistance",
 
   "attribute.hazennstuff.shadow_spell_power": "Shadow Spell Power",
-  "attribute.hazennstuff.shadow_spell_resist": "Shadow Spell Power",
+  "attribute.hazennstuff.shadow_magic_resist": "Shadow Magic Resistance",
 
   "material.hazennstuff.chlorophyte": "Chlorophyte",
   "material.hazennstuff.demonite": "Demonite",

--- a/src/main/resources/data/hazennstuff/worldgen/configured_feature/patch_fireblossom.json
+++ b/src/main/resources/data/hazennstuff/worldgen/configured_feature/patch_fireblossom.json
@@ -1,6 +1,9 @@
 {
   "type": "minecraft:random_patch",
   "config": {
+    "tries": 96,
+    "xz_spread": 7,
+    "y_spread": 3,
     "feature": {
       "feature": {
         "type": "minecraft:simple_block",
@@ -15,16 +18,35 @@
       },
       "placement": [
         {
+          "type": "minecraft:rarity_filter",
+          "chance": 3
+        },
+        {
           "type": "minecraft:block_predicate_filter",
           "predicate": {
-            "type": "minecraft:matching_blocks",
-            "blocks": "minecraft:air"
+            "type": "minecraft:all_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_blocks",
+                "blocks": [
+                  "minecraft:crimson_nylium"
+                ],
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ]
+              },
+              {
+                "type": "minecraft:matching_blocks",
+                "blocks": [
+                  "minecraft:air"
+                ]
+              }
+            ]
           }
         }
       ]
-    },
-    "tries": 96,
-    "xz_spread": 7,
-    "y_spread": 3
+    }
   }
 }

--- a/src/main/resources/data/hazennstuff/worldgen/placed_feature/fireblossom.json
+++ b/src/main/resources/data/hazennstuff/worldgen/placed_feature/fireblossom.json
@@ -2,23 +2,8 @@
   "feature": "hazennstuff:patch_fireblossom",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 2
-    },
-    {
-      "type": "minecraft:in_square"
-    },
-    {
-      "type": "minecraft:height_range",
-      "height": {
-        "type": "minecraft:uniform",
-        "max_inclusive": {
-          "below_top": 0
-        },
-        "min_inclusive": {
-          "above_bottom": 0
-        }
-      }
+      "type": "minecraft:count_on_every_layer",
+      "count": 1
     },
     {
       "type": "minecraft:biome"


### PR DESCRIPTION
Hello 👋 Love the new update, thought I'd submit a few patches for some minor issues I caught. 

Changes made by this PR:

## Fireblossom 
- Fixes Fireblossom feature generation never actually finding valid spots to place a patch making it unobtainable, fixes #14 

## Attribute Modifiers
- Adjusts all armor spell power modifiers of +0.x (and Apothic Attributes arrow damage/draw speed) from `ADD_VALUE` to `ADD_MULTIPLIED_BASE`. 
This is generally how both Iron's and Apotheosis handle these attributes, especially for base weapon modifiers. 

NOTES ON THIS: 
1. Attack speed in similar ranges using ADD_VALUE was *not* changed, though there were a few cases of +0.x attack speed, changing this to a multiplier would be a significantly different attack speed buff than the current modifier, so I left it alone. 
2. Crit chance was also not changed if it was ADD_VALUE - this attribute is auto-formatted to percent and is expected to be modified using ADD_VALUE even with 0.x amounts. 
3. Ascended Sacred Robes have a cooldown reduction per piece of +90%. Probably not intended but I didn't know where you wanted it, so I left it alone. 
4. Nothing in `HnSExtendedWeaponsTiers` was changed, though many of these weapons have innate `ADD_MULTIPLIED_TOTAL` modifiers for spell power instead of `ADD_MULTIPLIED_BASE`, which is very atypical. Wasn't sure if it was intended so I left it alone. 

## Lang
- Fixed translation keys for:
`attribute.hazennstuff.shadow_magic_resist`
`attribute.hazennstuff.radiance_magic_resist`

____ 

Feel free to do whatever you want with this. 