### PR TITLE
More patches! 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     compileOnly "curse.maven:apotheosis-${apotheosis_version}"
 
     //Ace Utils
-    implementation "curse.maven:ace_utils-1299492:7093024"
+    implementation "curse.maven:ace_utils-1299492:7104992"
 
     //AzureLib
     implementation "mod.azure.azurelib:azurelib-neo-${minecraft_version}:${azurelib_version}"

--- a/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MothicWitch/NerfedMothicWitchArmorItem.java
+++ b/src/main/java/net/hazen/hazennstuff/item/armor/Geckolib/MothicWitch/NerfedMothicWitchArmorItem.java
@@ -33,7 +33,7 @@ public class NerfedMothicWitchArmorItem extends ImbuableGeckolibHnSArmorItem imp
     public NerfedMothicWitchArmorItem(Type type, Properties settings) {
         // Add in your armor tier + additional attributes for your item
         super(HnSArmorMaterials.PURE_ARMOR_TIER_MATERIAL, type, settings,
-                new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                new AttributeContainer(AttributeRegistry.MAX_MANA, 150.0, AttributeModifier.Operation.ADD_VALUE),
                 new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
                 new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );

--- a/src/main/java/net/hazen/hazennstuff/item/curios/Crystals/LifeCrystals/SingularityCurio.java
+++ b/src/main/java/net/hazen/hazennstuff/item/curios/Crystals/LifeCrystals/SingularityCurio.java
@@ -32,7 +32,7 @@ public class SingularityCurio extends CurioBaseItem {
         attr.put(Attributes.MAX_HEALTH, new AttributeModifier(id, 20.0, AttributeModifier.Operation.ADD_VALUE));
         attr.put(ALObjects.Attributes.HEALING_RECEIVED, new AttributeModifier(id, 0.15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
         attr.put(ALObjects.Attributes.OVERHEAL, new AttributeModifier(id, 0.15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
-        attr.put(Attributes.ARMOR, new AttributeModifier(id, 3, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
+        attr.put(Attributes.ARMOR, new AttributeModifier(id, 3, AttributeModifier.Operation.ADD_VALUE));
         return attr;
     }
 }

--- a/src/main/java/net/hazen/hazennstuff/item/curios/Crystals/LifeCrystals/StrengthenedCurio.java
+++ b/src/main/java/net/hazen/hazennstuff/item/curios/Crystals/LifeCrystals/StrengthenedCurio.java
@@ -30,7 +30,7 @@ public class StrengthenedCurio extends CurioBaseItem {
         //The attributes of the curio
         attr.put(Attributes.MAX_HEALTH, new AttributeModifier(id, 15.0, AttributeModifier.Operation.ADD_VALUE));
         attr.put(ALObjects.Attributes.HEALING_RECEIVED, new AttributeModifier(id, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
-        attr.put(Attributes.ARMOR, new AttributeModifier(id, 1.5, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
+        attr.put(Attributes.ARMOR, new AttributeModifier(id, 1.5, AttributeModifier.Operation.ADD_VALUE));
         return attr;
     }
 }

--- a/src/main/java/net/hazen/hazennstuff/item/weapons/HnSExtendedWeaponsTiers.java
+++ b/src/main/java/net/hazen/hazennstuff/item/weapons/HnSExtendedWeaponsTiers.java
@@ -180,7 +180,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.PROT_PIERCE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.CRIT_CHANCE, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.EVOCATION_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     /*
@@ -197,7 +197,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.ARMOR_PIERCE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     public static HnSExtendedWeaponsTiers EXCALIBUR = new HnSExtendedWeaponsTiers(
@@ -210,7 +210,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.PROT_SHRED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     public static HnSExtendedWeaponsTiers DIVINE_GREATSWORD = new HnSExtendedWeaponsTiers(
@@ -222,7 +222,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             () -> Ingredient.of(HnSItems.ZENALITE_INGOT.get()),
             new AttributeContainer(ALObjects.Attributes.PROT_PIERCE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.ARMOR_PIERCE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.HOLY_SPELL_POWER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
 
     );
 
@@ -278,7 +278,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             () -> Ingredient.of(HnSItems.ZENALITE_INGOT.get()),
             new AttributeContainer(ASAttributeRegistry.MANA_REND, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.ARMOR_PIERCE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     public static HnSExtendedWeaponsTiers STARFURY = new HnSExtendedWeaponsTiers(
@@ -290,7 +290,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             () -> Ingredient.of(HnSItems.ZENALITE_INGOT.get()),
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.ARMOR_PIERCE, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, .05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     /*
@@ -306,7 +306,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             () -> Ingredient.of(HnSItems.ZENALITE_INGOT.get()),
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.LIFE_STEAL, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.BLOOD_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     /*
@@ -324,7 +324,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(ALObjects.Attributes.PROT_SHRED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ASAttributeRegistry.GOLIATH_SLAYER, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ASAttributeRegistry.MANA_REND, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
+            new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(Attributes.ENTITY_INTERACTION_RANGE, 3, AttributeModifier.Operation.ADD_VALUE)
     );
 
@@ -341,7 +341,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             () -> Ingredient.of(HnSItems.ZENALITE_INGOT.get()),
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(HnSAttributeRegistry.RADIANCE_MAGIC_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.NATURE_SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     public static HnSExtendedWeaponsTiers SPECTRUM = new HnSExtendedWeaponsTiers(
@@ -392,7 +392,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             BlockTags.INCORRECT_FOR_NETHERITE_TOOL,
             () -> Ingredient.of(HnSItems.ZENALITE_INGOT.get()),
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .1, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.SPELL_POWER, .15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     public static HnSExtendedWeaponsTiers TRUE_NIGHTS_EDGE = new HnSExtendedWeaponsTiers(
@@ -405,7 +405,7 @@ public class HnSExtendedWeaponsTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(ALObjects.Attributes.ARMOR_SHRED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.PROT_SHRED, .15, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
             new AttributeContainer(ALObjects.Attributes.CRIT_CHANCE, .2, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),
-            new AttributeContainer(AttributeRegistry.SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)
+            new AttributeContainer(AttributeRegistry.SPELL_POWER, .2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
     );
 
     /*

--- a/src/main/java/net/hazen/hazennstuff/registries/particle/General/HnSRodOfDiscordParticlesPacket.java
+++ b/src/main/java/net/hazen/hazennstuff/registries/particle/General/HnSRodOfDiscordParticlesPacket.java
@@ -33,7 +33,7 @@ public class HnSRodOfDiscordParticlesPacket implements CustomPacketPayload {
 
     public static void handle(HnSRodOfDiscordParticlesPacket packet, IPayloadContext context) {
         context.enqueueWork(() -> {
-            Level level = net.minecraft.client.Minecraft.getInstance().level;
+            Level level = context.player().level();
             if (level != null) {
                 ChaoticTeleportSpell.particleCloud(level, packet.pos1);
                 ChaoticTeleportSpell.particleCloud(level, packet.pos2);


### PR DESCRIPTION
🚶

Changes made by this PR: 
## Dedicated Server startup:
- Bumped Ace's Spell Utils (fixes their startup crash on servers, for dev environment)
- Fix this mod's dedicated server startup crash (in [HnSRodOfDiscordParticlesPacket.java](https://github.com/Hazentouvel/Hazen_N_Stuff/pull/17/commits/143a7835f3b943592f8643e6277a931cae2bc139#diff-e22854f86aceb8f5cbda5977f9cb09915aabd64f82785532be4b6e060eeeb2cb), retrieve the level from `context.player().level()` instead of attempting to use `Minecraft.getInstance().level`). This fixes #16 

## Modifier Operation fixes: 
All spell power on weapons:
Multiply total -> multiply base (standard for innate spell power weapon attributes)

NerfedMothicWitchArmorItem:
+15000% Mana -> +150 Mana

SingularityCurio:
+300% Armor -> +3 Armor

StrengthenedCurio:
+150% Armor -> +1.5 Armor
